### PR TITLE
Fixing regex to work non-formatted xsd files

### DIFF
--- a/xsd_download.py
+++ b/xsd_download.py
@@ -68,7 +68,7 @@ def recursive_get_schema_locations(url):
             print('ERROR loading {} REASON: {} '.format(url, e.reason))
             return
         # all the XSDs linked from this file via schemaLocation
-        schema_locations = re.findall('schemaLocation="(.*)"', xsd_data)
+        schema_locations = re.findall('schemaLocation="([^"]*)"', xsd_data)
 
         # write this file in the directory structure
         save_file(url, xsd_data)


### PR DESCRIPTION
The existing regex includes to much. It matches to the last " on the line, which is not necessarily the closing quote of schemaLocation.